### PR TITLE
Update exceptions.md

### DIFF
--- a/pages/docs/reference/exceptions.md
+++ b/pages/docs/reference/exceptions.md
@@ -117,6 +117,7 @@ fun fail(message: String): Nothing {
 }
 ```
 </div>
+
 当你调用该函数时，编译器会知道调用后不会继续执行：
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>

--- a/pages/docs/reference/exceptions.md
+++ b/pages/docs/reference/exceptions.md
@@ -117,8 +117,7 @@ fun fail(message: String): Nothing {
 }
 ```
 </div>
-
-当你调用该函数时，编译器会知道执行不会超出该调用：
+当你调用该函数时，编译器会知道调用后不会继续执行：
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 ```kotlin


### PR DESCRIPTION
121行  当你调用该函数时，编译器会知道执行不会超出该调用：
表达不是很明确，似乎这样好一些：
当你调用该函数时，编译器会知道调用后不会继续执行：

这里，s的类型其实是联合类型（Union Type：String|Nothing）

<!--
感谢你的贡献！
如果只是修正格式、错别字请忽略以下这段。如果提交翻译 PR（Pull Request），为了统一风格、提升质量、便于维护，请务必细看以下说明：
---
目前《翻译指南》还在制订中，不过在 [#35](https://github.com/hltj/kotlin-web-site-cn/issues/35) 中有一部分草稿版。
如果初次翻译，请确保提 PR 前你已经读过 #35 以及其中的链接，并且已按照这些地方的说明来修改原稿。

以下是 checklist，请在发起 PR 时认真填写（完成项在 [ ] 内将空格替换为 X）。
为避免重复劳动（确实对有些贡献者的翻译进行校对的过程如同重新翻译一遍……），如有多项未完成则不予合并，还请理解与配合。
-->
- [x] 已仔细阅读 #⁠35 及其中链接的内容
- [x] 阅读过 Kotlin 参考的大部分章节
- [ ] 每一句都已经过谷歌机翻作为参考
- [ ] 每一句都已经过搜狗机翻作为参考
- [ ] 翻译中所用术语均与术语表中一致
- [ ] 注释也已翻译，除了 `//sampleStart` 与 `//sampleEnd`
- [ ] 正文与注释中的标点均已使用全角
- [ ] 中文与英文/数字之间、中文与 `` ` `` 之间都以空格分隔
- [ ] 英文与标点之间未留空格
- [ ] 行级对照，中文句子中间断行处已使用 HTML 注释
