### PR TITLE
别字修改

### DIFF
--- a/pages/docs/reference/collection-write.md
+++ b/pages/docs/reference/collection-write.md
@@ -8,7 +8,7 @@ title: "集合写操作"
 # 集合写操作
 
 [可变集合](collections-overview.html#集合类型)支持更改集合内容的操作，例如添加或删除元素。
-在次页面上，我们将描述实现 `MutableCollection` 的所有写操作。
+在此页面上，我们将描述实现 `MutableCollection` 的所有写操作。
 有关 `List` 与 `Map` 可用的更多特定操作，请分别参见 [List 相关操作](list-operations.html)与 [Map 相关操作](map-operations.html)。
 
 ## 添加元素


### PR DESCRIPTION
集合写操作描述由"在次页面上"改为"在此页面上"，这里"次"应该是别字

<!--
感谢你的贡献！
如果只是修正格式、错别字请忽略以下这段。如果提交翻译 PR（Pull Request），为了统一风格、提升质量、便于维护，请务必细看以下说明：
---
目前《翻译指南》还在制订中，不过在 [#35](https://github.com/hltj/kotlin-web-site-cn/issues/35) 中有一部分草稿版。
如果初次翻译，请确保提 PR 前你已经读过 #35 以及其中的链接，并且已按照这些地方的说明来修改原稿。

以下是 checklist，请在发起 PR 时认真填写（完成项在 [ ] 内将空格替换为 X）。
为避免重复劳动（确实对有些贡献者的翻译进行校对的过程如同重新翻译一遍……），如有多项未完成则不予合并，还请理解与配合。
-->
- [ ] 已仔细阅读 #⁠35 及其中链接的内容
- [ ] 阅读过 Kotlin 参考的大部分章节
- [ ] 每一句都已经过谷歌机翻作为参考
- [ ] 每一句都已经过搜狗机翻作为参考
- [ ] 翻译中所用术语均与术语表中一致
- [ ] 注释也已翻译，除了 `//sampleStart` 与 `//sampleEnd`
- [ ] 正文与注释中的标点均已使用全角
- [ ] 中文与英文/数字之间、中文与 `` ` `` 之间都以空格分隔
- [ ] 英文与标点之间未留空格
- [ ] 行级对照，中文句子中间断行处已使用 HTML 注释
