### PR TITLE
翻译 导出依赖项到二进制文件

### DIFF
--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -2138,11 +2138,11 @@ binaries {
 </div>
 </div>
 
-#### 导出依赖项为二进制文件
+#### 导出依赖项到二进制文件
 
-When building an Objective-C framework or a native library (shared or static), it is often necessary to pack not just the
-classes of the current project, but also the classes of some of its dependencies. The Binaries DSL allows one to specify
-which dependencies will be exported to a binary using the `export` method. Note that only API dependencies of a corresponding source set can be exported.
+当构建 Objective-C framework 或原生库（共享或静态），经常不仅要打包当前项目的
+class，还需要打包其某些依赖项的 class。binaries DSL 允许使用 `export`
+方法指定将哪些依赖项将导出到二进制文件。注意，仅有相应源集的 API 依赖项可以被导出。
 
 <div class="multi-language-sample" data-lang="groovy">
 <div class="sample" markdown="1" theme="idea" mode='groovy'>
@@ -2151,11 +2151,11 @@ which dependencies will be exported to a binary using the `export` method. Note 
 kotlin {
     sourceSets {
         macosMain.dependencies {
-            // Will be exported.
+            // 将被导出。
             api project(':dependency')
             api 'org.example:exported-library:1.0'
 
-            // Will not be exported.
+            // 将不被导出。
             api 'org.example:not-exported-library:1.0'
         }
     }
@@ -2167,7 +2167,7 @@ kotlin {
         }
 
         sharedLib {
-            // It's possible to export different sets of dependencies to different binaries.
+            // 可以将不同的依赖项集合导出到不同的二进制文件。
             export project(':dependency')
         }
     }
@@ -2184,11 +2184,11 @@ kotlin {
 kotlin {
     sourceSets {
         macosMain.dependencies {
-            // Will be exported.
+            // 将被导出。
             api(project(":dependency"))
             api("org.example:exported-library:1.0")
 
-            // Will not be exported.
+            // 将不被导出。
             api("org.example:not-exported-library:1.0")
         }
     }
@@ -2200,7 +2200,7 @@ kotlin {
         }
 
         sharedLib {
-            // It's possible to export different sets of dependencies to different binaries.
+            // 可以将不同的依赖项集合导出到不同的二进制文件。
             export(project(':dependency'))
         }
     }
@@ -2210,12 +2210,12 @@ kotlin {
 </div>
 </div>
 
-> As shown in this example, maven dependency also can be exported. But due to current limitations of Gradle metadata such a dependency
-should be either a platform one (e.g. `kotlinx-coroutines-core-native_debug_macos_x64` instead of `kotlinx-coroutines-core-native`)
-or be exported transitively (see below).
+> 如这个示例所展示的，maven 依赖项也可以被导出。但由于 Gradle 元数据的当前限制，这种依赖项<!--
+-->应该是平台依赖（例如 `kotlinx-coroutines-core-native_debug_macos_x64` 而不是 `kotlinx-coroutines-core-native`）
+或过渡导出（参见下文）。
 
-By default, export works non-transitively. If a library `foo` depending on library `bar` is exported, only methods of `foo` will
-be added in the output framework. This behaviour can be changed by the `transitiveExport` flag.
+默认情况下，导出工作是不过渡的。如果导出了依赖于库 `bar` 的库 `foo`，那么仅有 `foo` 的方法将<!--
+-->被添加到输出 framework。这个行为可以通过 `transitiveExport` flag 来改变。
 
 <div class="multi-language-sample" data-lang="groovy">
 <div class="sample" markdown="1" theme="idea" mode='groovy'>
@@ -2224,7 +2224,7 @@ be added in the output framework. This behaviour can be changed by the `transiti
 binaries {
     framework {
         export project(':dependency')
-        // Export transitively.
+        // 过渡地导出。
         transitiveExport = true
     }
 }
@@ -2240,7 +2240,7 @@ binaries {
 binaries {
     framework {
         export(project(":dependency"))
-        // Export transitively.
+        // 过渡地导出。
         transitiveExport = true
     }
 }

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -2214,7 +2214,7 @@ kotlin {
 -->应该是平台依赖（例如 `kotlinx-coroutines-core-native_debug_macos_x64` 而不是 `kotlinx-coroutines-core-native`）
 或被传递地导出（参见下文）。
 
-默认情况下，导出工作是不传递的。如果导出了依赖于库 `bar` 的库 `foo`，那么仅有 `foo` 的方法将<!--
+默认情况下，导出工作是非传递性的。如果导出了依赖于库 `bar` 的库 `foo`，那么仅有 `foo` 的方法将<!--
 -->被添加到输出 framework。这个行为可以通过 `transitiveExport` 标志来改变。
 
 <div class="multi-language-sample" data-lang="groovy">

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -2140,7 +2140,7 @@ binaries {
 
 #### 导出依赖项到二进制文件
 
-当构建 Objective-C framework 或原生库（共享或静态），经常不仅要打包当前项目的
+当构建 Objective-C framework 或原生库（共享或静态）时，经常不仅要打包当前项目的
 class，还需要打包其某些依赖项的 class。binaries DSL 允许使用 `export`
 方法指定将哪些依赖项将导出到二进制文件。注意，仅有相应源集的 API 依赖项可以被导出。
 
@@ -2212,10 +2212,10 @@ kotlin {
 
 > 如这个示例所展示的，maven 依赖项也可以被导出。但由于 Gradle 元数据的当前限制，这种依赖项<!--
 -->应该是平台依赖（例如 `kotlinx-coroutines-core-native_debug_macos_x64` 而不是 `kotlinx-coroutines-core-native`）
-或过渡导出（参见下文）。
+或被传递地导出（参见下文）。
 
-默认情况下，导出工作是不过渡的。如果导出了依赖于库 `bar` 的库 `foo`，那么仅有 `foo` 的方法将<!--
--->被添加到输出 framework。这个行为可以通过 `transitiveExport` flag 来改变。
+默认情况下，导出工作是不传递的。如果导出了依赖于库 `bar` 的库 `foo`，那么仅有 `foo` 的方法将<!--
+-->被添加到输出 framework。这个行为可以通过 `transitiveExport` 标志来改变。
 
 <div class="multi-language-sample" data-lang="groovy">
 <div class="sample" markdown="1" theme="idea" mode='groovy'>


### PR DESCRIPTION
<!--
感谢你的贡献！
如果只是修正格式、错别字请忽略以下这段。如果提交翻译 PR（Pull Request），为了统一风格、提升质量、便于维护，请务必细看以下说明：
---
目前《翻译指南》还在制订中，不过在 [#35](https://github.com/hltj/kotlin-web-site-cn/issues/35) 中有一部分草稿版。
如果初次翻译，请确保提 PR 前你已经读过 #35 以及其中的链接，并且已按照这些地方的说明来修改原稿。

以下是 checklist，请在发起 PR 时认真填写（完成项在 [ ] 内将空格替换为 X）。
为避免重复劳动（确实对有些贡献者的翻译进行校对的过程如同重新翻译一遍……），如有多项未完成则不予合并，还请理解与配合。
-->
- [x] 已仔细阅读 #⁠35 及其中链接的内容
- [x] 阅读过 Kotlin 参考的大部分章节
- [x] 每一句都已经过谷歌机翻作为参考
- [ ] 每一句都已经过搜狗机翻作为参考
- [x] 翻译中所用术语均与术语表中一致
- [x] 注释也已翻译，除了 `//sampleStart` 与 `//sampleEnd`
- [x] 正文与注释中的标点均已使用全角
- [x] 中文与英文/数字之间、中文与 `` ` `` 之间都以空格分隔
- [x] 英文与标点之间未留空格
- [x] 行级对照，中文句子中间断行处已使用 HTML 注释
