### PR TITLE
[翻译完毕！] 语言指南 - 类与对象 - 委托属性 - #delegating-to-another-property

### DIFF
--- a/pages/docs/reference/delegated-properties.md
+++ b/pages/docs/reference/delegated-properties.md
@@ -153,16 +153,16 @@ fun main() {
 如果你想截获赋值并“否决”它们，那么使用 [`vetoable()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.properties/-delegates/vetoable.html) 取代 `observable()`。
 在属性被赋新值生效*之前*会调用传递给 `vetoable` 的处理程序。
 
-## Delegating to another property
+## 委托给另一个属性
 
-Since Kotlin 1.4, a property can delegate its getter and setter to another property. Such delegation is available for
-both top-level and class properties (member and extension). The delegate property can be:
-- a top-level property
-- a member or an extension property of the same class
-- a member or an extension property of another class
+从 Kotlin 1.4 开始，一个属性可以把它的 getter 与 setter 委托给另一个属性。这种委托<!--
+-->对于顶层和类的属性（成员和扩展）都可用。该委托属性可以为：
+- 顶层属性
+- 同一个类的成员或扩展属性
+- 另一个类的成员或扩展属性
 
-To delegate a property to another property, use the proper `::` qualifier in the delegate name, for example, `this::delegate` or
-`MyClass::delegate`.
+为将一个属性委托给另一个属性，应在委托名称中使用恰当的 `::` 限定符，例如，`this::delegate` 或
+`MyClass::delegate`。
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
@@ -183,8 +183,8 @@ var MyClass.extDelegated: Int by ::topLevelInt
 
 </div>
 
-This may be useful, for example, when you want to rename a property in a backward-compatible way: you introduce a new property,
-annotate the old one with the `@Deprecated` annotation, and delegate its implementation.
+这是很有用的，例如，当想要以一种向后兼容的方式重命名一个属性的时候：引入一个新的属性、
+使用 `@Deprecated` 注解来注解旧的属性、并委托其实现。
 
 <div class="sample" markdown="1" theme="idea">
 
@@ -197,7 +197,7 @@ class MyClass {
 
 fun main() {
    val myClass = MyClass()
-   // Notification: 'oldName: Int' is deprecated.
+   // 通知：'oldName: Int' is deprecated.
    // Use 'newName' instead
    myClass.oldName = 42
    println(myClass.newName) // 42


### PR DESCRIPTION
<!--
感谢你的贡献！
如果只是修正格式、错别字请忽略以下这段。如果提交翻译 PR（Pull Request），为了统一风格、提升质量、便于维护，请务必细看以下说明：
---
目前《翻译指南》还在制订中，不过在 [#35](https://github.com/hltj/kotlin-web-site-cn/issues/35) 中有一部分草稿版。
如果初次翻译，请确保提 PR 前你已经读过 #35 以及其中的链接，并且已按照这些地方的说明来修改原稿。

以下是 checklist，请在发起 PR 时认真填写（完成项在 [ ] 内将空格替换为 X）。
为避免重复劳动（确实对有些贡献者的翻译进行校对的过程如同重新翻译一遍……），如有多项未完成则不予合并，还请理解与配合。
-->
- [X] 已仔细阅读 #⁠35 及其中链接的内容
- [X] 阅读过 Kotlin 参考的大部分章节
- [X] 每一句都已经过谷歌机翻作为参考
- [ ] 每一句都已经过搜狗机翻作为参考
- [X] 翻译中所用术语均与术语表中一致
- [x] 注释也已翻译，除了 `//sampleStart` 与 `//sampleEnd`
- [X] 正文与注释中的标点均已使用全角
- [X] 中文与英文/数字之间、中文与 `` ` `` 之间都以空格分隔
- [X] 英文与标点之间未留空格
- [X] 行级对照，中文句子中间断行处已使用 HTML 注释
